### PR TITLE
remove ecr url from jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('tools') _
 
 kanikoBuild {
-    registry ${env.ECRREPO}
+    registry "${env.ECRREPO}"
     image "${getEcrEnv()}/app/gitlab/gitlab-exporter"
     tags "v${env.BUILD_ID}", 'latest'
     ecrDeleteLatest true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('tools') _
 
 kanikoBuild {
-    registry '136813947591.dkr.ecr.us-east-1.amazonaws.com'
+    registry ${env.ECRREPO}
     image "${getEcrEnv()}/app/gitlab/gitlab-exporter"
     tags "v${env.BUILD_ID}", 'latest'
     ecrDeleteLatest true


### PR DESCRIPTION
I was checking my old repos in github and I noticed this:

It's not needed anymore but better to "hide" the ECR url because this repo is public. Nobody can do anything with the aws account ID but better to don't expose it that openly.
You will have to add the global variable `ECRREPO` to jenkins-ai with the value `DEVOPS-ACCOUNT-ID.dkr.ecr.us-east-1.amazonaws.com` before merge to Prod, I added manually only to test but you will have to add it as code because I will lose my access soon hehe.

I know it will be in the history but better this than nothing.